### PR TITLE
Youtube Search Results Render

### DIFF
--- a/scratch/fake-search-results.js
+++ b/scratch/fake-search-results.js
@@ -1,0 +1,172 @@
+/* eslint-disable quotes */
+export const fakeSearchResults = {
+  kind: "youtube#searchListResponse",
+  etag: "\"Fznwjl6JEQdo1MGvHOGaz_YanRU/V56sTKoMDp8yx0YAlURuSAqshgg\"",
+  nextPageToken: "CAUQAA",
+  regionCode: "US",
+  pageInfo: {
+    totalResults: 1000000,
+    resultsPerPage: 5
+  },
+  items: [
+    {
+      kind: "youtube#searchResult",
+      etag: "\"Fznwjl6JEQdo1MGvHOGaz_YanRU/YCed2NvZsJ5uIMb5W60VYK9ZABo\"",
+      id: {
+        kind: "youtube#video",
+        videoId: "CcNo07Xp8aQ"
+      },
+      snippet: {
+        publishedAt: "2010-05-28T18:10:03.000Z",
+        channelId: "UCX6kV7z1OW-x24NwvXzyY5Q",
+        title: "Robyn - Dancing On My Own (Official Video)",
+        description: "Follow & Hear More From Robyn : https://rbn.lnk.to/FollowYD Music video by Robyn performing Dancing On My Own. (C) 2010 Konichiwa / Cherrytree ...",
+        thumbnails: {
+          default: {
+            url: "https://i.ytimg.com/vi/CcNo07Xp8aQ/default.jpg",
+            width: 120,
+            height: 90
+          },
+          medium: {
+            url: "https://i.ytimg.com/vi/CcNo07Xp8aQ/mqdefault.jpg",
+            width: 320,
+            height: 180
+          },
+          high: {
+            url: "https://i.ytimg.com/vi/CcNo07Xp8aQ/hqdefault.jpg",
+            width: 480,
+            height: 360
+          }
+        },
+        channelTitle: "RobynVEVO",
+        liveBroadcastContent: "none"
+      }
+    },
+    {
+      kind: "youtube#searchResult",
+      etag: "\"Fznwjl6JEQdo1MGvHOGaz_YanRU/zDUcJxYZODiXS0lelPKuT7XpXTg\"",
+      id: {
+        kind: "youtube#channel",
+        channelId: "UCC_JSfQlhrKeA_jNeqhLAiA"
+      },
+      snippet: {
+        publishedAt: "2007-05-17T10:11:30.000Z",
+        channelId: "UCC_JSfQlhrKeA_jNeqhLAiA",
+        title: "Robyn",
+        description: "Robyn's album Honey is out now: https://rbn.lnk.to/HONEYALBUMYD Pre-save Missing U here: https://rbn.lnk.to/MissingUYo Follow & Hear More From Robyn ...",
+        thumbnails: {
+          default: {
+            url: "https://yt3.ggpht.com/-Nq1SiM0fFuM/AAAAAAAAAAI/AAAAAAAAAAA/sktl5KspSYM/s88-c-k-no-mo-rj-c0xffffff/photo.jpg"
+          },
+          medium: {
+            url: "https://yt3.ggpht.com/-Nq1SiM0fFuM/AAAAAAAAAAI/AAAAAAAAAAA/sktl5KspSYM/s240-c-k-no-mo-rj-c0xffffff/photo.jpg"
+          },
+          high: {
+            url: "https://yt3.ggpht.com/-Nq1SiM0fFuM/AAAAAAAAAAI/AAAAAAAAAAA/sktl5KspSYM/s800-c-k-no-mo-rj-c0xffffff/photo.jpg"
+          }
+        },
+        channelTitle: "Robyn",
+        liveBroadcastContent: "upcoming"
+      }
+    },
+    {
+      kind: "youtube#searchResult",
+      etag: "\"Fznwjl6JEQdo1MGvHOGaz_YanRU/z29APilfdWUtoaa3YtneEsv9SZw\"",
+      id: {
+        kind: "youtube#video",
+        videoId: "F6ImxY6hnfA"
+      },
+      snippet: {
+        publishedAt: "2011-06-03T16:30:05.000Z",
+        channelId: "UCX6kV7z1OW-x24NwvXzyY5Q",
+        title: "Robyn - Call Your Girlfriend (Official Video)",
+        description: "Follow & Hear More From Robyn : https://rbn.lnk.to/FollowYD Music video by Robyn performing Call Your Girlfriend. (C) 2011 Konichiwa Records, under ...",
+        thumbnails: {
+          default: {
+            url: "https://i.ytimg.com/vi/F6ImxY6hnfA/default.jpg",
+            width: 120,
+            height: 90
+          },
+          medium: {
+            url: "https://i.ytimg.com/vi/F6ImxY6hnfA/mqdefault.jpg",
+            width: 320,
+            height: 180
+          },
+          high: {
+            url: "https://i.ytimg.com/vi/F6ImxY6hnfA/hqdefault.jpg",
+            width: 480,
+            height: 360
+          }
+        },
+        channelTitle: "RobynVEVO",
+        liveBroadcastContent: "none"
+      }
+    },
+    {
+      kind: "youtube#searchResult",
+      etag: "\"Fznwjl6JEQdo1MGvHOGaz_YanRU/835wW4qkRMvt2S6Jfinz5eG7184\"",
+      id: {
+        kind: "youtube#video",
+        videoId: "GfK88LsB0fg"
+      },
+      snippet: {
+        publishedAt: "2019-06-17T13:00:03.000Z",
+        channelId: "UCX6kV7z1OW-x24NwvXzyY5Q",
+        title: "Robyn - Ever Again",
+        description: "Music video by Robyn performing Ever Again. © 2019 Konichiwa Records, under exclusive licence to Universal Music Operations Limited Ever Again is taken ...",
+        thumbnails: {
+          default: {
+            url: "https://i.ytimg.com/vi/GfK88LsB0fg/default.jpg",
+            width: 120,
+            height: 90
+          },
+          medium: {
+            url: "https://i.ytimg.com/vi/GfK88LsB0fg/mqdefault.jpg",
+            width: 320,
+            height: 180
+          },
+          high: {
+            url: "https://i.ytimg.com/vi/GfK88LsB0fg/hqdefault.jpg",
+            width: 480,
+            height: 360
+          }
+        },
+        channelTitle: "RobynVEVO",
+        liveBroadcastContent: "none"
+      }
+    },
+    {
+      kind: "youtube#searchResult",
+      etag: "\"Fznwjl6JEQdo1MGvHOGaz_YanRU/vD-UXPfXBZ4Hcpd1ZEBKNn80EQI\"",
+      id: {
+        kind: "youtube#video",
+        videoId: "bhWEI6-_w9E"
+      },
+      snippet: {
+        publishedAt: "2009-11-26T04:32:04.000Z",
+        channelId: "UCX6kV7z1OW-x24NwvXzyY5Q",
+        title: "Robyn - Show Me Love (Official Video)",
+        description: "Music video by Robyn Carlsson performing Show Me Love. (C) 1997 Ricochet/BMG Sweden AB #Robyn #ShowMeLove #Vevo.",
+        thumbnails: {
+          default: {
+            url: "https://i.ytimg.com/vi/bhWEI6-_w9E/default.jpg",
+            width: 120,
+            height: 90
+          },
+          medium: {
+            url: "https://i.ytimg.com/vi/bhWEI6-_w9E/mqdefault.jpg",
+            width: 320,
+            height: 180
+          },
+          high: {
+            url: "https://i.ytimg.com/vi/bhWEI6-_w9E/hqdefault.jpg",
+            width: 480,
+            height: 360
+          }
+        },
+        channelTitle: "RobynVEVO",
+        liveBroadcastContent: "none"
+      }
+    }
+  ]
+};

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,6 +1,6 @@
 import React from 'react';
+import Mixt from './mixt/Mixt.js';
 
 export default function App() {
-  return <h1>Hello World</h1>;
+  return <Mixt />;
 }
-  

--- a/src/components/searchResultSection/SearchResultSection.js
+++ b/src/components/searchResultSection/SearchResultSection.js
@@ -1,15 +1,54 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import SearchResultSectionItem from '../searchResultSectionItem/SearchResultSectionItem.js';
+import PropTypes from 'prop-types';
 
-export default function SearchResultSection() {
+export default function SearchResultSection({ results }) {
+  const [simplifiedResults, setSimplifiedResults] = useState([]); 
+
+  console.log('raw results: ', results);
+  
+  //check source of search results to munge songs correctly
+  //add field to easily specify source
+  let songArray;
+  if(results.kind === 'youtube#searchListResponse') {
+    songArray = results.items;
+    results.nativeSource = 'youtube';
+  }
+
+  console.log('raw songs: ', songArray);
+
+  //save an array of simplified results to state
+  //NOTE: IF IT TURNS OUT DIFFERENT APIS RETURN DIFFERENTLY FORMATTED RESULTS,
+  //WE MAY NEED TO MAKE A SearchResultSection COMPONENT FOR EACH API.
+  useEffect(() => {
+    setSimplifiedResults(songArray.map(result => ({
+      nativeId: result.id.videoId,
+      nativeSource: results.nativeSource,
+      title: result.snippet.title
+    })));
+  }, []);
+
+  console.log('simplified results: ', simplifiedResults);
+
+  //Create an item for each simplified result
+  const resultItems = simplifiedResults.map((item, i) => (
+    <li key={i}>
+      <SearchResultSectionItem data={item} />
+    </li>
+  ));
 
   return (
     <>
       <ul>
-        <h4>This is an example of a search result section</h4>
-        <p>It will be a list of search results</p>
+        <h4>This is an example of a search result section for youtube</h4>
+        {resultItems}
         <p>Each search result should be demoable</p>
         <p>Should be able to add to the Edit section</p>
       </ul>
     </>
   );
 }
+
+SearchResultSection.propTypes = {
+  results: PropTypes.object.isRequired
+};

--- a/src/components/searchResultSectionItem/SearchResultSectionItem.js
+++ b/src/components/searchResultSectionItem/SearchResultSectionItem.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function SearchResultSectionItem({ data }) {
+
+  return (
+    <span>
+      {data.title}
+      <button>+</button>
+      <button>Demo</button>
+    </span>
+  );
+}
+
+SearchResultSectionItem.propTypes = {
+  data: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    nativeSource: PropTypes.string.isRequired,
+    nativeId: PropTypes.string.isRequired
+  }).isRequired
+};

--- a/src/components/searchSongs/SearchSongs.js
+++ b/src/components/searchSongs/SearchSongs.js
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useState } from 'react';
 import SearchResultSection from '../searchResultSection/SearchResultSection.js';
+import { fakeSearchResults as fakeYoutubeResults } from '../../../scratch/fake-search-results.js';
 
 export default function SearchSongs() {
+  //default state will be deleted once fetches are implemented
+  const [results, setResults] = useState([fakeYoutubeResults, {}]);
+
+  //Some fetch to hit all of the search APIs
+  //Need to do in a promise.all
+  //Result will be an array of results from each source
+
+  //for each source of search results, create a component with props.
+  //prop is the raw search result from a source.
+  //If a source didn't return any results, filter it out.
+  const resultSections = results.map((section, i) => {
+    if(Object.entries(section).length !== 0) {
+      return (
+        <li key={i}>
+          <SearchResultSection results={section} />
+        </li>
+      );
+    } else return;
+  }).filter(item => !!item);
 
   return (
     <>
       <h3>This is the Song Search Section</h3>
       <h4>It has a search form</h4>
-      <SearchResultSection />
+      <ul>
+        {resultSections}
+      </ul>
     </>
   );
 }


### PR DESCRIPTION
Youtube search results render in a SearchResultSection component. Multiple SearchResultSection components will be rendered, one for each source of data. It remains to be seen if a generic component can be used for each source, or if a unique one needs to be made for munging purposes. Chances are, logic for munging can be extracted out of the component into a separate function file, make the component source agnostic.

Items just need a title (combined artist and track name), nativeID, and nativeSource currently. We may need to expand it if we need things like thumbnails.